### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ which offers tutorials, samples, guidance on mobile development, and a full API 
 
 2. Using [Gradle](https://gradle.org/) and [CocoaPods](https://cocoapods.org) to add platform-specific dependencies.
 
+    * Using *CocoaPods* in *terminal*
+      * do `$ cd ios/` 
+      * then `$ pod update` or `$ pod install --repo-update`
+    * *Gradle*
+      * TODO
+
 ### Initialization
 
 1. import `package:leancloud_official_plugin/leancloud_plugin.dart` in `lib/main.dart` of your project, like this:
@@ -56,30 +62,122 @@ which offers tutorials, samples, guidance on mobile development, and a full API 
 
     @UIApplicationMain
     @objc class AppDelegate: FlutterAppDelegate {
-      override func application(
-        _ application: UIApplication,
-        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-      ) -> Bool {
-        do {
-          LCApplication.logLevel = .all
-          try LCApplication.default.set(
-            id: YOUR_LC_APP_ID,
-            key: YOUR_LC_APP_KEY,
-            serverURL: YOUR_LC_SERVER_URL)
-          GeneratedPluginRegistrant.register(with: self)
-          return super.application(application, didFinishLaunchingWithOptions: launchOptions)
-        } catch {
-          fatalError("\(error)")
+        override func application(
+            _ application: UIApplication,
+            didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+        ) -> Bool {
+            do {
+                LCApplication.logLevel = .all
+                try LCApplication.default.set(
+                    id: YOUR_LC_APP_ID,
+                    key: YOUR_LC_APP_KEY,
+                    serverURL: YOUR_LC_SERVER_URL)
+                GeneratedPluginRegistrant.register(with: self)
+                return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+            } catch {
+                fatalError("\(error)")
+            }
         }
-      }
     }
     ```
 
-### Sample Code
+### Push setup (optional)
+
+Due to different push service in iOS and Android, the setup-code should be wrote in native platform. 
+it's optional, so if you no need of push service, you can ignore this section.
+
+* iOS
+
+    ```swift
+    import Flutter
+    import LeanCloud
+    import UserNotifications
+
+    @UIApplicationMain
+    @objc class AppDelegate: FlutterAppDelegate {
+        override func application(
+            _ application: UIApplication,
+            didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+        ) -> Bool {
+            do {
+                LCApplication.logLevel = .all
+                try LCApplication.default.set(
+                    id: YOUR_LC_APP_ID,
+                    key: YOUR_LC_APP_KEY,
+                    serverURL: YOUR_LC_SERVER_URL)
+                GeneratedPluginRegistrant.register(with: self)
+                /*
+                register APNs to access token, like this:
+                */ 
+                UNUserNotificationCenter.current().getNotificationSettings { (settings) in
+                    switch settings.authorizationStatus {
+                    case .authorized:
+                        DispatchQueue.main.async {
+                            UIApplication.shared.registerForRemoteNotifications()
+                        }
+                    case .notDetermined:
+                        UNUserNotificationCenter.current().requestAuthorization(options: [.badge, .alert, .sound]) { (granted, error) in
+                            if granted {
+                                DispatchQueue.main.async {
+                                    UIApplication.shared.registerForRemoteNotifications()
+                                }
+                            }
+                        }
+                    default:
+                        break
+                    }
+                }
+                return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+            } catch {
+                fatalError("\(error)")
+            }
+        }
+    }
+
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) 
+        /* 
+        set APNs deviceToken and Team ID.
+        */
+        LCApplication.default.currentInstallation
+            .set(
+                deviceToken: deviceToken,
+                apnsTeamId: YOUR_APNS_TEAM_ID)
+        /* 
+        add `client-id` to `channels`, you can use flutter platform channels to pass `client-id` from flutter to native platform.
+
+        flutter platform channels reference: 
+            https://flutter.dev/docs/development/platform-integration/platform-channels
+        */
+        try LCApplication.default.currentInstallation
+            .append(
+                "channels",
+                element: YOUR_CLIENT_ID,
+                unique: true)
+        /* 
+        save to LeanCloud.
+        */
+        LCApplication.default.currentInstallation.save { (result) in
+            switch result {
+            case .success:
+                break
+            case .failure(error: let error):
+                print(error)
+            }
+        }
+    }
+    ```
+
+* Android
+
+    ```java
+    TODO
+    ```
+
+## Sample Code
 
 After initialization, you can write some sample code and run it to check whether initializing success, like this:
 
-#### Open
+### Open
 
 ```dart
 // new an IM client
@@ -88,7 +186,7 @@ Client client = Client(id: CLIENT_ID);
 await client.open();
 ```
 
-#### Query Conversations
+### Query Conversations
 
 ```dart
 // the ID of the conversation instance list


### PR DESCRIPTION
目前推送的设置代码还得在 Native 端由开发者来配置，所以有一个参考对开发者会更友好一些。

我更新了 iOS 端的 Push 代码设置的文档， @jwfing 考虑把 Android 的 Push 设置代码也加上？